### PR TITLE
Python Version and OS conditions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,8 @@ jobs:
         python -m nafas test
     - name: Install dev-requirements
       run: |
-        pip install --upgrade --upgrade-strategy=only-if-needed -r dev-requirements.txt
+        python otherfiles/requirements-splitter.py
+        pip install --upgrade --upgrade-strategy=only-if-needed -r test-requirements.txt
     - name: Version check
       run: |
         python otherfiles/version_check.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Version check
       run: |
         python otherfiles/version_check.py
+      if: matrix.python-version == 3.7
     - name: Test with pytest
       run: |
         python -m pytest test --cov=nafas --cov-report=term
@@ -41,6 +42,8 @@ jobs:
         python -m vulture nafas/ setup.py --min-confidence 65 --exclude=__init__.py --sort-by-size
         python -m bandit -r nafas -s B311
         python -m pydocstyle --match-dir=nafas -v
+      if: matrix.python-version == 3.7
     - name: Codecov
       run: |
         codecov
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `requirements-splitter.py`
+### Changed
+- Test system modified
 ## [0.3] - 2021-02-09
 ### Changed
 - Sounds bug in pypi fixed

--- a/otherfiles/requirements-splitter.py
+++ b/otherfiles/requirements-splitter.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Requirements splitter."""
+
+test_req = ""
+
+with open('dev-requirements.txt', 'r') as f:
+    for line in f:
+        if '==' not in line:
+            test_req += line
+
+with open('test-requirements.txt', 'w') as f:
+    f.write(test_req)


### PR DESCRIPTION
+ `Version Check` is now just tested on `python 3.7`
+ `Other tests` are now just tested on `python 3.7`
+ `CodeCov` working on `python 3.7` and `Ubuntu-latest` 
+ `requirements-splitter.py` added